### PR TITLE
Added oamlGodotModule::ReadDefsFile function

### DIFF
--- a/oamlGodotModule.cpp
+++ b/oamlGodotModule.cpp
@@ -123,6 +123,13 @@ void oamlGodotModule::InitString(String defs) {
 	oaml->InitString(defs.ascii());
 }
 
+void oamlGodotModule::ReadDefsFile(String defsFilename) {
+	if (oaml == NULL)
+		return;
+
+	oaml->ReadDefsFile(defsFilename.ascii().get_data());
+}
+
 bool oamlGodotModule::IsPaused() {
 	if (oaml == NULL)
 		return true;
@@ -275,6 +282,7 @@ void oamlGodotModule::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_volume"), &oamlGodotModule::GetVolume);
 	ClassDB::bind_method(D_METHOD("init", "defsFilename"), &oamlGodotModule::Init);
 	ClassDB::bind_method(D_METHOD("init_string", "defs"), &oamlGodotModule::InitString);
+	ClassDB::bind_method(D_METHOD("read_defs_file", "defsFilename"), &oamlGodotModule::ReadDefsFile);
 	ClassDB::bind_method(D_METHOD("is_paused"), &oamlGodotModule::IsPaused);
 	ClassDB::bind_method(D_METHOD("is_playing"), &oamlGodotModule::IsPlaying);
 	ClassDB::bind_method(D_METHOD("is_track_playing", "name"), &oamlGodotModule::IsTrackPlaying);

--- a/oamlGodotModule.h
+++ b/oamlGodotModule.h
@@ -42,6 +42,7 @@ public:
 	float GetVolume();
 	void Init(String defsFilename);
 	void InitString(String defs);
+	void ReadDefsFile(String defsFilename);
 	bool IsPaused();
 	bool IsPlaying();
 	bool IsTrackPlaying(String name);


### PR DESCRIPTION
This pull requests allows ReadDefsFile to be called from the oamlGodotModule class, necessary for loading multiple OAML definitions (as I do in Wyrmsun for instance; and I am currently adapting Wyrmsun's engine Wyrmgus to become a Godot module).