### PR TITLE
oamlGodotModule Node Inheritance

### DIFF
--- a/oamlGodotModule.h
+++ b/oamlGodotModule.h
@@ -4,11 +4,11 @@
 #include "servers/audio_server.h"
 #include "servers/audio/audio_stream.h"
 #include "oaml.h"
-#include "core/reference.h"
+#include "scene/main/node.h"
 
 
-class oamlGodotModule : public Reference {
-	GDCLASS(oamlGodotModule, Reference)
+class oamlGodotModule : public Node {
+	GDCLASS(oamlGodotModule, Node)
 
 	int sp_get_channel_count() const;
 	bool mix(AudioFrame *p_buffer, int p_frames);


### PR DESCRIPTION
This pull request makes the oamlGodotModule class inherit from Node instead of from Reference, for the reasons detailed in issue #8 . Namely, it can now be instanced directly, without needing to be a member variable of a node.

For example: without this change, I had to have an otherwise empty node containing OAML in order to use the latter. I called this node "music_player", and the oamlGodotModule instance "oaml_module". To interact with OAML, then, I needed to make calls like this:

```
music_player.oaml_module.play_track("MenuTheme")
```

With this pull request, I can instance OAML directly as a node. So I removed the parent node from the process, and renamed the oamlGodotModule instance to "music_player", and now I call it directly, like this:

```
music_player.play_track("MenuTheme")
```